### PR TITLE
out-of-bounds in menu->entries array

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -1764,7 +1764,7 @@ static void menuMouseDown(WObjDescriptor * desc, XEvent * event)
 		goto byebye;
 	}
 	entry_no = getEntryAt(menu, x, y);
-	if (entry_no >= 0) {
+	if ((entry_no >= 0) && (entry_no < menu->entry_no)) {
 		entry = menu->entries[entry_no];
 
 		if (!close_on_exit && (bev->state & ControlMask) && smenu && entry->flags.editable) {
@@ -1940,7 +1940,7 @@ static void menuMouseDown(WObjDescriptor * desc, XEvent * event)
 
 			if (!delayed_select) {
 				entry_no = getEntryAt(menu, x, y);
-				if (entry_no >= 0) {
+				if ((entry_no >= 0) && (entry_no < menu->entry_no)) {
 					entry = menu->entries[entry_no];
 					if (entry->flags.enabled && entry->cascade >= 0 && menu->cascades) {
 						WMenu *submenu = menu->cascades[entry->cascade];


### PR DESCRIPTION
bug description:
after menu is displayed I get a segfault when trying to hover over the last menu entry. it looks like under some circumstances menu->entries[] gets accessed past the last valid value (off by one).

how to reproduce:
right-click desktop to show menu and keep right mouse button pressed sweep mouse up-down the menu a few times - it crashes all the time between 1-5 sweeps

this commit fixes the unwanted behaviour, in active use since december 2021.